### PR TITLE
Use Gson single static instance

### DIFF
--- a/src/main/java/com/tradeshift/flagr/EvaluationContext.java
+++ b/src/main/java/com/tradeshift/flagr/EvaluationContext.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
 public class EvaluationContext {
+    private static final Gson gson = new Gson();
+
     // entityID is used to to evaluate the flag.
     private String entityID;
 
@@ -34,13 +36,11 @@ public class EvaluationContext {
     }
 
     public <T> T getEntityContext(Class<T> entityClass) {
-        Gson gson = new Gson();
         T entity = gson.fromJson(entityContext, entityClass);
         return entity;
     }
 
     public <T> void setEntityContext(T entityContext) {
-        Gson gson = new Gson();
         this.entityContext = gson.toJsonTree(entityContext);
     }
 

--- a/src/main/java/com/tradeshift/flagr/EvaluationResponse.java
+++ b/src/main/java/com/tradeshift/flagr/EvaluationResponse.java
@@ -6,6 +6,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
 public class EvaluationResponse {
+    private static final Gson gson = new Gson();
+
     private Long flagID;
     private String flagKey;
     private Long flagSnapshotID;
@@ -19,7 +21,6 @@ public class EvaluationResponse {
     private EvalDebugLog evalDebugLog;
 
     public <T> EvaluationResponse(Long flagID, String flagKey, Long flagSnapshotID, Long segmentID, Long variantID, String variantKey, T variantAttachment, EvaluationContext evaluationContext, Timestamp timestamp, EvalDebugLog evalDebugLog) {
-        Gson gson = new Gson();
         this.variantAttachment = gson.toJsonTree(variantAttachment);
 
         this.flagID = flagID;
@@ -70,7 +71,6 @@ public class EvaluationResponse {
     }
 
     public <T> T getVariantAttachment(Class<T> variantClass) {
-        Gson gson = new Gson();
         T variant = gson.fromJson(variantAttachment, variantClass);
         return variant;
     }

--- a/src/main/java/com/tradeshift/flagr/Flagr.java
+++ b/src/main/java/com/tradeshift/flagr/Flagr.java
@@ -28,6 +28,8 @@ public class Flagr {
             Arrays.asList("on", "enabled", "true")
     );
 
+    private static final Gson gson = new Gson();
+
     private String host;
     private OkHttpClient http;
 
@@ -113,7 +115,6 @@ public class Flagr {
     }
 
     private String serialize(EvaluationContext obj) {
-        Gson gson = new Gson();
         return gson.toJson(obj);
     }
 
@@ -138,7 +139,6 @@ public class Flagr {
     }
 
     private EvaluationResponse deserializeResponseBody(ResponseBody responseBody) throws FlagrException {
-        Gson gson = new Gson();
         EvaluationResponse response = gson.fromJson(responseBody.charStream(), EvaluationResponse.class);
         if (response == null) {
             throw new FlagrException("Unable to parse json response");


### PR DESCRIPTION
Gson object is expensive to create as it uses reflection and
class scanning. A Gson object was created several times during
a single evaluate request.
This makes static Gson instances that are reused between calls.
Gson is thread safe.