### PR TITLE
POPS-1992 Bump okhttp version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.5.0</version>
+      <version>3.12.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This commit bumps okhttp version to mitigate:
```
~/Tradeshift/flagr-java (bump-okta)
(prod_prod:default)
└─ $ trivy fs .
2022-05-03T11:01:15.698+0200	INFO	Number of language-specific files: 1
2022-05-03T11:01:15.698+0200	INFO	Detecting pom vulnerabilities...

pom.xml (pom)
=============
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

+-----------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|           LIBRARY           | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+-----------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| com.squareup.okhttp3:okhttp | CVE-2018-20200   | MEDIUM   | 3.5.0             | 3.12.1        | okhttp: certificate pinning bypass    |
|                             |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-20200 |
+-----------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
```