### PR TITLE
chore: change of ownership from developer-productivity to platform-ops

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tradeshift/developer-productivity @Tradeshift/ci-workers
+* @Tradeshift/platform-ops @Tradeshift/ci-workers

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -11,5 +11,5 @@ metadata:
     - flagr
 spec:
   type: library
-  owner: developer-productivity
+  owner: platform-ops
   lifecycle: production


### PR DESCRIPTION
This PR changes the ownership of this repo to platform-ops, as the developer productivity team doesn't exist anymore.